### PR TITLE
feat: add slider for filter threshold value

### DIFF
--- a/_js/_form.js
+++ b/_js/_form.js
@@ -20,6 +20,12 @@ class pdvForm {
 		radioScaleOutside.addEventListener('change', e => {
 			this.triggerFormScaleChangeEvent(e);
 		});
+		
+		// Threshold value
+		const thresholdInput = document.querySelector('input[name="threshold"]')
+		thresholdInput.addEventListener('change', e => {
+			this.triggerFormThresholdChangeEvent(e);
+		});
 
 		// File input
 		const fileInput = document.querySelector('form input[type="file"]')
@@ -49,6 +55,13 @@ class pdvForm {
 
 	triggerFormScaleChangeEvent(evt) {
 		document.dispatchEvent(new CustomEvent('pdvFormScaleChange', {
+			bubbles: true,
+			detail: evt.target.value
+		}));
+	}
+
+	triggerFormThresholdChangeEvent(evt) {
+		document.dispatchEvent(new CustomEvent('pdvFormThresholdChange', {
 			bubbles: true,
 			detail: evt.target.value
 		}));

--- a/_js/_preview.js
+++ b/_js/_preview.js
@@ -45,6 +45,10 @@ class pdvPreview {
 			this.setScale(e.detail);
 		});
 
+		document.addEventListener('pdvFormThresholdChange', e => {
+			this.setThreshold(e.detail);
+		});
+
 		document.addEventListener('pdvFormVideoChange', () => {
 			this.setVideo();
 		});
@@ -138,6 +142,10 @@ class pdvPreview {
 			this.scale = "outside";
 			this.video.style.objectFit = "cover";
 		}
+	}
+
+	setThreshold(value) {
+		this.filterThreshold = value;
 	}
 
 	setVideo() {

--- a/index.html
+++ b/index.html
@@ -29,6 +29,11 @@ layout: default
 				<option value="sierralite">Sierra Lite</option>
 			</select>
 		</div>
+		<div style="width:500px;">
+			<label for="input-threshold">Threshold Value: </label>
+			<input type="range" id="input-threshold" name="threshold" value="127" min="0" max="255" oninput="this.nextElementSibling.value = this.value">
+			<output for="input-threshold">127</output>
+		</div>
 		<div>
 			<span class="form-label">Scale to fit</span>
 			<div>


### PR DESCRIPTION
Added a little feature for my own project to be able to set a filter threshold value other than 127, might be useful to others as well :)

I'm not really experienced in html, so I'm not too sure about the `style="width:500px;"` which is used to make sure the line is not re-centered when the text width changes (threshold value with 1,2,3 digits).
Would be great if there's a better solution for this!

Preview video:

https://github.com/hteumeuleu/pdv/assets/1075032/5a775c61-0db9-46cf-9bde-90ec5d5abb5c

